### PR TITLE
(feat) support alias, create lb, healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this module will be documented in this file.
 
+## [1.1.2] - 2022-08-30
+
+Here we would have the update steps for 1.1.2 for people to follow.
+
+### Added
+
+- variables
+  - `is_create_private_lb`
+- support route53 alias
+
+### Changed
+
+- change 443 health check to TCP by default
+
 ## [1.1.1] - 2022-08-10
 
 Here we would have the update steps for 1.1.1 for people to follow.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ mongorestore /efs/dump
 | <a name="input_enabled_backup"></a> [enabled\_backup](#input\_enabled\_backup) | Enable Backup EFS | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment Variable used as a prefix | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | (Optional) The instance type to use for the instance. Updates to this field will trigger a stop/start of the EC2 instance. | `string` | `"t2.medium"` | no |
+| <a name="input_is_create_private_lb"></a> [is\_create\_private\_lb](#input\_is\_create\_private\_lb) | if true this module will not create private lb for cost optimization | `bool` | `true` | no |
 | <a name="input_is_create_route53_reccord"></a> [is\_create\_route53\_reccord](#input\_is\_create\_route53\_reccord) | if true will create route53 reccord for vpn, vpn console | `bool` | `false` | no |
 | <a name="input_is_create_security_group"></a> [is\_create\_security\_group](#input\_is\_create\_security\_group) | Flag to toggle security group creation | `bool` | `true` | no |
 | <a name="input_is_enabled_https_public"></a> [is\_enabled\_https\_public](#input\_is\_enabled\_https\_public) | if true will enable https to public loadbalancer else enable to private loadbalancer | `bool` | `true` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,7 +1,10 @@
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
@@ -20,12 +23,16 @@ No resources.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment Variable used as a prefix | `string` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix name of customer to be displayed in AWS console and resource | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to add more; default tags contian {terraform=true, environment=var.environment} | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_dns"></a> [dns](#output\_dns) | n/a |
-| <a name="output_efs_id"></a> [efs\_id](#output\_efs\_id) | n/a |
+| <a name="output_vpn_private_dns"></a> [vpn\_private\_dns](#output\_vpn\_private\_dns) | private dns for connect vpn server |
+| <a name="output_vpn_public_dns"></a> [vpn\_public\_dns](#output\_vpn\_public\_dns) | public dns for connect vpn server |
 <!-- END_TF_DOCS -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,13 +7,7 @@ module "vpn" {
   private_subnet_ids        = module.vpc.private_subnet_ids
   instance_type             = "t3a.small"
   is_create_route53_reccord = false
+  is_create_private_lb      = true
   is_enabled_https_public   = true
-  security_group_ingress_rules = {
-    allow_to_connect_vpn = {
-      port        = "12383"
-      cidr_blocks = ["0.0.0.0/0"]
-      protocol    = "udp"
-    }
-  }
-  tags = var.tags
+  tags                      = var.tags
 }

--- a/lb.tf
+++ b/lb.tf
@@ -39,6 +39,7 @@ resource "aws_lb_listener" "public" {
 
 # LoadBalancer Private
 resource "aws_lb" "private" {
+  count              = var.is_create_private_lb ? 1 : 0
   name               = format("%s-private-lb", local.name)
   internal           = true
   load_balancer_type = "network"
@@ -51,7 +52,7 @@ resource "aws_lb" "private" {
 }
 
 resource "aws_lb_target_group" "private" {
-  count              = length(local.private_rule)
+  count              = var.is_create_private_lb ? length(local.private_rule) : 0
   name               = format("%s-private-%s", local.name, count.index)
   preserve_client_ip = false
   port               = local.private_rule[count.index].port
@@ -59,14 +60,14 @@ resource "aws_lb_target_group" "private" {
   vpc_id             = var.vpc_id
 
   health_check {
-    port     = lookup(local.public_rule[count.index], "health_check_port", null)
-    protocol = lookup(local.public_rule[count.index], "health_check_protocol", null)
+    port     = lookup(local.private_rule[count.index], "health_check_port", null)
+    protocol = lookup(local.private_rule[count.index], "health_check_protocol", null)
   }
 }
 
 resource "aws_lb_listener" "private" {
-  count             = length(local.private_rule)
-  load_balancer_arn = aws_lb.private.arn
+  count             = var.is_create_private_lb ? length(local.private_rule) : 0
+  load_balancer_arn = aws_lb.private[0].arn
   port              = local.private_rule[count.index].port
   protocol          = local.private_rule[count.index].protocol
 

--- a/locals.tf
+++ b/locals.tf
@@ -10,12 +10,13 @@ locals {
   profile_policy_arns = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientReadWriteAccess"]
   security_group_ids  = concat([module.efs.security_group_client_id], var.additional_sg_attacment_ids, var.is_create_security_group ? [aws_security_group.this[0].id] : [])
 
-
-  public_rule = concat(var.public_rule, var.is_enabled_https_public ? [{
-    port     = 443
-    protocol = "TCP"
-  }] : [])
-  private_rule             = concat(var.private_rule, [{ port = 443, protocol = "TCP" }])
+  console_rule = [{
+    port                  = 443,
+    protocol              = "TCP"
+    health_check_protocol = "TCP"
+  }]
+  public_rule              = concat(var.public_rule, var.is_enabled_https_public ? local.console_rule : [])
+  private_rule             = concat(var.private_rule, local.console_rule)
   default_https_allow_cidr = var.is_enabled_https_public ? ["0.0.0.0/0"] : [data.aws_vpc.this.cidr_block]
   security_group_ingress_rules = merge({
     allow_to_config_vpn = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "lb_public_dns" {
 
 output "lb_private_dns" {
   description = "The DNS name of the private load balancer."
-  value       = aws_lb.private.dns_name
+  value       = try(aws_lb.private[0].dns_name, "")
 }
 
 output "vpn_public_dns" {
@@ -14,7 +14,7 @@ output "vpn_public_dns" {
 }
 
 output "vpn_private_dns" {
-  value       = try(aws_route53_record.private[0].name, aws_lb.private.dns_name)
+  value       = try(aws_route53_record.private[0].name, try(aws_lb.private[0].dns_name, ""))
   description = "private dns for connect vpn server"
 }
 

--- a/route53.tf
+++ b/route53.tf
@@ -7,16 +7,22 @@ resource "aws_route53_record" "public" {
   count   = var.is_create_route53_reccord ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
   name    = format("%s.%s", var.public_lb_vpn_domain, var.route53_zone_name)
-  type    = "CNAME"
-  ttl     = "300"
-  records = [aws_lb.public.dns_name]
+  type    = "A"
+  alias {
+    name                   = aws_lb.public.dns_name
+    zone_id                = aws_lb.public.zone_id
+    evaluate_target_health = true
+  }
 }
 
 resource "aws_route53_record" "private" {
-  count   = var.is_create_route53_reccord ? 1 : 0
+  count   = var.is_create_private_lb && var.is_create_route53_reccord ? 1 : 0
   zone_id = data.aws_route53_zone.this[0].zone_id
   name    = format("%s.%s", var.private_lb_vpn_domain, var.route53_zone_name)
-  type    = "CNAME"
-  ttl     = "300"
-  records = [aws_lb.private.dns_name]
+  type    = "A"
+  alias {
+    name                   = aws_lb.private[0].dns_name
+    zone_id                = aws_lb.private[0].zone_id
+    evaluate_target_health = true
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,9 @@ variable "enable_ec2_monitoring" {
   type        = bool
   default     = false
 }
+
+variable "is_create_private_lb" {
+  description = "if true this module will not create private lb for cost optimization"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## What :kissing:

### Added

- variables
  - `is_create_private_lb`
- support route53 alias

### Changed

- change 443 health check to TCP by default


## Why :pleading_face:

- default rule bug
- support route53 alias for better practice

## Other Info

- none

