### PR TITLE
allow customizing access point details

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -9,22 +9,9 @@ module "efs" {
   encrypted                 = true
   enabled_backup            = var.enabled_backup
   efs_backup_policy_enabled = var.efs_backup_policy_enabled
-  access_points = {
-    "data" = {
-      posix_user = {
-        gid            = "1001"
-        uid            = "5000"
-        secondary_gids = "1002,1003"
-      }
-      creation_info = {
-        gid         = "1001"
-        uid         = "5000"
-        permissions = "0755"
-      }
-    }
-  }
-  vpc_id  = var.vpc_id
-  subnets = var.private_subnet_ids
+  access_points             = var.access_points
+  vpc_id                    = var.vpc_id
+  subnets                   = var.private_subnet_ids
 
   additional_efs_resource_policies = []
 }

--- a/iam.tf
+++ b/iam.tf
@@ -24,6 +24,25 @@ data "aws_iam_policy_document" "this" {
       values   = ["ec2.amazonaws.com"]
     }
   }
+  statement {
+    sid    = "Route53List"
+    effect = "Allow"
+    actions = [
+      "route53:ListHostedZones",
+      "route53:GetChange"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "Route53Change"
+    effect = "Allow"
+    actions = [
+      "route53:ChangeResourceRecordSets"
+    ]
+    resources = [
+      data.aws_route53_zone.this[0].arn
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "this_assume_role" {

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -9,6 +9,7 @@ module "launch_template" {
     {
       efs_id              = module.efs.id
       efs_access_point_id = module.efs.access_point_ids["data"]
+      domain              = var.route53_zone_name
   }))
   iam_instance_profile   = { arn : aws_iam_instance_profile.this.arn }
   ami_id                 = var.ami == "" ? data.aws_ami.amazon_linux.id : var.ami

--- a/launch-template.tf
+++ b/launch-template.tf
@@ -7,7 +7,8 @@ module "launch_template" {
   name        = "pritunl-vpn"
   user_data = base64encode(templatefile("${path.module}/template/user_data.sh",
     {
-      efs_id = module.efs.id
+      efs_id              = module.efs.id
+      efs_access_point_id = module.efs.access_point_ids["data"]
   }))
   iam_instance_profile   = { arn : aws_iam_instance_profile.this.arn }
   ami_id                 = var.ami == "" ? data.aws_ami.amazon_linux.id : var.ami

--- a/template/user_data.sh
+++ b/template/user_data.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -x
 
+sudo amazon-linux-extras install -y epel
 sudo yum update -y
-sudo yum -y install wget
+sudo yum install -y wget certbot python2-certbot-dns-route53
 if [[ "$(python3 -V 2>&1)" =~ ^(Python 3.6.*) ]]; then
     sudo wget https://bootstrap.pypa.io/pip/3.6/get-pip.py -O /tmp/get-pip.py
 elif [[ "$(python3 -V 2>&1)" =~ ^(Python 3.5.*) ]]; then
@@ -43,6 +44,8 @@ sudo yum -y install pritunl mongodb-org-5.0.9-1.amzn2
 
 sudo sed -i.bak "s/\/var\/lib\/mongo/\/mnt\/efs/g" /etc/mongod.conf
 sudo chown -R mongod:mongod /mnt/efs/
+
+sudo certbot certonly --dns-route53 --dns-route53-propagation-seconds 30 -m devops@eaze.com --agree-tos -n -d vpn.${domain} -d vpn-console.${domain}
 
 sudo systemctl start mongod pritunl
 sudo systemctl enable mongod pritunl

--- a/template/user_data.sh
+++ b/template/user_data.sh
@@ -15,7 +15,7 @@ sudo python3 /tmp/get-pip.py
 sudo /usr/local/bin/pip3 install botocore
 sudo yum install -y amazon-efs-utils
 sudo mkdir /mnt/efs
-echo "${efs_id}:/ /mnt/efs efs _netdev,noresvport,tls,iam 0 0" | sudo tee -a /etc/fstab
+echo "${efs_id}:/ /mnt/efs efs _netdev,noresvport,tls,iam,accesspoint=${efs_access_point_id} 0 0" | sudo tee -a /etc/fstab
 sudo mount -a
 sudo tee /etc/yum.repos.d/mongodb-org-5.0.repo << EOF
 [mongodb-org-5.0]

--- a/template/user_data.sh
+++ b/template/user_data.sh
@@ -47,6 +47,9 @@ sudo chown -R mongod:mongod /mnt/efs/
 
 sudo certbot certonly --dns-route53 --dns-route53-propagation-seconds 30 -m devops@eaze.com --agree-tos -n -d vpn.${domain} -d vpn-console.${domain}
 
+sudo pritunl set app.server_cert "$(cat /etc/letsencrypt/live/vpn.${domain}/cert.pem)"
+sudo pritunl set app.server_key "$(cat /etc/letsencrypt/live/vpn.${domain}/privkey.pem)"
+
 sudo systemctl start mongod pritunl
 sudo systemctl enable mongod pritunl
 sudo pritunl set-mongodb mongodb://localhost:27017/pritunl

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,25 @@ variable "security_group_ingress_rules" {
   }
 }
 
+variable "access_points" {
+  description = "Map of access point UID/GID configurations"
+  type        = any
+  default = {
+    "data" = {
+      posix_user = {
+        gid            = "1001"
+        uid            = "5000"
+        secondary_gids = "1002,1003"
+      }
+      creation_info = {
+        gid         = "1001"
+        uid         = "5000"
+        permissions = "0755"
+      }
+    }
+  }
+}
+
 variable "is_create_security_group" {
   description = "Flag to toggle security group creation"
   type        = bool


### PR DESCRIPTION
## Added `access_points` variable

### Changes

- Changed module `efs` to have a customizable `access_points` parameter

## Why :pleading_face:

- Fix bug on latest AMI where `mongod` UID/GID has changed, breaking bootstrapping.
